### PR TITLE
Fix typo

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,6 +67,7 @@ module.exports.SRC_SELF = '\'self\'';
 module.exports.SRC_NONE = '\'none\'';
 /** Allows use of inline source elements such as style attribute and onclick */
 module.exports.SRC_USAFE_INLINE = '\'unsafe-inline\'';
+module.exports.SRC_UNSAFE_INLINE = '\'unsafe-inline\'';
 /** Allows unsafe dynamic code evaluation such as JavaScript eval() */
 module.exports.SRC_UNSAFE_EVAL = '\'unsafe-eval\'';
 /** Allows loading resources via the data scheme (e.g. Base64 encoded images). */


### PR DESCRIPTION
`SRC_USAFE_INLINE` should be `SRC_UNSAFE_INLINE` :)

I still kept the old one though just to avoid breaking changes in the library. 🤷‍♀️